### PR TITLE
Update PlayerState UniqueId after Login

### DIFF
--- a/AdvancedSessions/Source/AdvancedSessions/Private/LoginUserCallbackProxy.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/LoginUserCallbackProxy.cpp
@@ -64,6 +64,7 @@ void ULoginUserCallbackProxy::OnCompleted(int32 LocalUserNum, bool bWasSuccessfu
 	if (PlayerControllerWeakPtr.IsValid())
 	{
 		ULocalPlayer* Player = Cast<ULocalPlayer>(PlayerControllerWeakPtr->Player);
+		auto uniqueId = UserId.AsShared();
 
 		if (Player)
 		{
@@ -73,6 +74,15 @@ void ULoginUserCallbackProxy::OnCompleted(int32 LocalUserNum, bool bWasSuccessfu
 			{
 				Identity->ClearOnLoginCompleteDelegate_Handle(Player->GetControllerId(), DelegateHandle);
 			}
+			Player->SetCachedUniqueNetId(uniqueId);
+		}
+
+		APlayerState* State = PlayerControllerWeakPtr->PlayerState;
+
+		if (State)
+		{
+			// Update UniqueId. See also ShowLoginUICallbackProxy.cpp
+			State->SetUniqueId(uniqueId);
 		}
 	}
 

--- a/AdvancedSessions/Source/AdvancedSessions/Private/LoginUserCallbackProxy.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/LoginUserCallbackProxy.cpp
@@ -82,7 +82,7 @@ void ULoginUserCallbackProxy::OnCompleted(int32 LocalUserNum, bool bWasSuccessfu
 		if (State)
 		{
 			// Update UniqueId. See also ShowLoginUICallbackProxy.cpp
-			State->SetUniqueId(uniqueId);
+			State->SetUniqueId((const FUniqueNetIdPtr&) uniqueId);
 		}
 	}
 


### PR DESCRIPTION
For the OSS EOS, the playerstate uniqueid needs to be set after login. Otherwise, creating a session using the CreateAdvancedSession node will fail.

This is also done in ShowLoginUICallbackProxy.cpp (see https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Plugins/Online/OnlineSubsystemUtils/Source/OnlineSubsystemUtils/Private/ShowLoginUICallbackProxy.cpp), so it should be done in general.

This code has been tested in a patched (custom) version of the plugin, I've created a video explaining how to use the Advanced Sessions plugin with OSS EOS: https://youtu.be/b7-h54najFY

