### PR TITLE
Rename Login parameter "Type" to "AuthType".

### DIFF
--- a/AdvancedSessions/Source/AdvancedSessions/Classes/LoginUserCallbackProxy.h
+++ b/AdvancedSessions/Source/AdvancedSessions/Classes/LoginUserCallbackProxy.h
@@ -21,8 +21,8 @@ class ULoginUserCallbackProxy : public UOnlineBlueprintCallProxyBase
 	FEmptyOnlineDelegate OnFailure;
 
 	// Logs into the identity interface
-	UFUNCTION(BlueprintCallable, meta=(BlueprintInternalUseOnly = "true", WorldContext="WorldContextObject", AdvancedDisplay = "Type"), Category = "Online|AdvancedIdentity")
-	static ULoginUserCallbackProxy* LoginUser(UObject* WorldContextObject, class APlayerController* PlayerController, FString UserID, FString UserToken, FString Type);
+	UFUNCTION(BlueprintCallable, meta=(BlueprintInternalUseOnly = "true", WorldContext="WorldContextObject", AdvancedDisplay = "AuthType"), Category = "Online|AdvancedIdentity")
+	static ULoginUserCallbackProxy* LoginUser(UObject* WorldContextObject, class APlayerController* PlayerController, FString UserID, FString UserToken, FString AuthType);
 
 	// UOnlineBlueprintCallProxyBase interface
 	virtual void Activate() override;
@@ -42,7 +42,7 @@ private:
 	// The user pass / token
 	FString UserToken;
 
-	FString Type;
+	FString AuthType;
 
 	// The delegate executed by the online subsystem
 	FOnLoginCompleteDelegate Delegate;

--- a/AdvancedSessions/Source/AdvancedSessions/Private/LoginUserCallbackProxy.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/LoginUserCallbackProxy.cpp
@@ -12,13 +12,13 @@ ULoginUserCallbackProxy::ULoginUserCallbackProxy(const FObjectInitializer& Objec
 {
 }
 
-ULoginUserCallbackProxy* ULoginUserCallbackProxy::LoginUser(UObject* WorldContextObject, class APlayerController* PlayerController, FString UserID, FString UserToken, FString Type)
+ULoginUserCallbackProxy* ULoginUserCallbackProxy::LoginUser(UObject* WorldContextObject, class APlayerController* PlayerController, FString UserID, FString UserToken, FString AuthType)
 {
 	ULoginUserCallbackProxy* Proxy = NewObject<ULoginUserCallbackProxy>();
 	Proxy->PlayerControllerWeakPtr = PlayerController;
 	Proxy->UserID = UserID;
 	Proxy->UserToken = UserToken;
-	Proxy->Type = Type;
+	Proxy->AuthType = AuthType;
 	Proxy->WorldContextObject = WorldContextObject;
 	return Proxy;
 }
@@ -45,12 +45,12 @@ void ULoginUserCallbackProxy::Activate()
 	if (Identity.IsValid())
 	{
 		// Fallback to default AuthType if nothing is specified
-		if (Type.IsEmpty())
+		if (AuthType.IsEmpty())
 		{
-			Type = Identity->GetAuthType();
+			AuthType = Identity->GetAuthType();
 		}
 		DelegateHandle = Identity->AddOnLoginCompleteDelegate_Handle(Player->GetControllerId(), Delegate);
-		FOnlineAccountCredentials AccountCreds(Type, UserID, UserToken);
+		FOnlineAccountCredentials AccountCreds(AuthType, UserID, UserToken);
 		Identity->Login(Player->GetControllerId(), AccountCreds);
 		return;
 	}


### PR DESCRIPTION
It is great that the new AuthType parameter (specifically for EOS) is already present in the current git version!
I would suggest to call it AuthType, since "Type" is too generic (and the plugin was not yet published with this parameter name).

This may seem like a small thing, but the name AuthType clarifies that this is related to authentication, while "Type" may also mean User Type (due to the other user parameters).

However, this pull request is just a suggestion and completely optional :-)