### PR TITLE
issue-31: Add option to skip starting a game session after it's created

### DIFF
--- a/AdvancedSessions/Source/AdvancedSessions/Classes/CreateSessionCallbackProxyAdvanced.h
+++ b/AdvancedSessions/Source/AdvancedSessions/Classes/CreateSessionCallbackProxyAdvanced.h
@@ -27,9 +27,10 @@ class UCreateSessionCallbackProxyAdvanced : public UOnlineBlueprintCallProxyBase
 	 *	  @param bUseLobbiesIfAvailable Used to flag the subsystem to use a lobby api instead of general hosting if the API supports it, generally true on steam for listen servers and false for dedicated
 	 *	  @param bShouldAdvertise	Set to true when the OnlineSubsystem should list your server when someone is searching for servers. Otherwise the server is hidden and only join via invite is possible.
 	 *	  @param bUseLobbiesVoiceChatIfAvailable Set to true to setup voice chat lobbies if the API supports it
+	 *	  @param bStartAfterCreate Set to true to start the session after it's created.
 	 */
 	UFUNCTION(BlueprintCallable, meta=(BlueprintInternalUseOnly = "true", WorldContext="WorldContextObject",AutoCreateRefTerm="ExtraSettings"), Category = "Online|AdvancedSessions")
-	static UCreateSessionCallbackProxyAdvanced* CreateAdvancedSession(UObject* WorldContextObject, const TArray<FSessionPropertyKeyPair> &ExtraSettings, class APlayerController* PlayerController = NULL, int32 PublicConnections = 100, int32 PrivateConnections = 0, bool bUseLAN = false, bool bAllowInvites = true, bool bIsDedicatedServer = false, bool bUsePresence = true, bool bUseLobbiesIfAvailable = true, bool bAllowJoinViaPresence = true, bool bAllowJoinViaPresenceFriendsOnly = false, bool bAntiCheatProtected = false, bool bUsesStats = false, bool bShouldAdvertise = true, bool bUseLobbiesVoiceChatIfAvailable = false);
+	static UCreateSessionCallbackProxyAdvanced* CreateAdvancedSession(UObject* WorldContextObject, const TArray<FSessionPropertyKeyPair> &ExtraSettings, class APlayerController* PlayerController = NULL, int32 PublicConnections = 100, int32 PrivateConnections = 0, bool bUseLAN = false, bool bAllowInvites = true, bool bIsDedicatedServer = false, bool bUsePresence = true, bool bUseLobbiesIfAvailable = true, bool bAllowJoinViaPresence = true, bool bAllowJoinViaPresenceFriendsOnly = false, bool bAntiCheatProtected = false, bool bUsesStats = false, bool bShouldAdvertise = true, bool bUseLobbiesVoiceChatIfAvailable = false, bool bStartAfterCreate = true);
 
 	// UOnlineBlueprintCallProxyBase interface
 	virtual void Activate() override;
@@ -39,7 +40,7 @@ private:
 	// Internal callback when session creation completes, calls StartSession
 	void OnCreateCompleted(FName SessionName, bool bWasSuccessful);
 
-	// Internal callback when session creation completes, calls StartSession
+	// Internal callback when session start completes
 	void OnStartCompleted(FName SessionName, bool bWasSuccessful);
 
 	// The player controller triggering things
@@ -93,6 +94,9 @@ private:
 
 	// Whether to prefer the use of voice chat lobbies if the api supports them
 	bool bUseLobbiesVoiceChatIfAvailable;
+
+	// Whether to start the session automatically after it is created
+	bool bStartAfterCreate;
 
 	// Store extra settings
 	TArray<FSessionPropertyKeyPair> ExtraSettings;

--- a/AdvancedSessions/Source/AdvancedSessions/Classes/StartSessionCallbackProxyAdvanced.h
+++ b/AdvancedSessions/Source/AdvancedSessions/Classes/StartSessionCallbackProxyAdvanced.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BlueprintDataDefinitions.h"
+#include "StartSessionCallbackProxyAdvanced.generated.h"
+
+UCLASS(MinimalAPI)
+class UStartSessionCallbackProxyAdvanced : public UOnlineBlueprintCallProxyBase
+{
+	GENERATED_UCLASS_BODY()
+	// Called when the session starts successfully
+	UPROPERTY(BlueprintAssignable)
+	FEmptyOnlineDelegate OnSuccess;
+
+	// Called when there is an error starting the session
+	UPROPERTY(BlueprintAssignable)
+	FEmptyOnlineDelegate OnFailure;
+
+	/**
+	 * Starts a session with the default online subsystem. The session needs to be previously created by calling the "CreateAdvancedSession" node.
+	 * @param WorldContextObject
+	 */
+	UFUNCTION(
+		BlueprintCallable
+		, meta=(BlueprintInternalUseOnly = "true", WorldContext="WorldContextObject")
+		, Category = "Online|AdvancedSessions"
+	)
+	static UStartSessionCallbackProxyAdvanced* StartAdvancedSession(const UObject* WorldContextObject);
+
+	// UOnlineBlueprintCallProxyBase interface
+	virtual void Activate() override;
+	// End of UOnlineBlueprintCallProxyBase interface
+
+private:
+	// Internal callback when session start completes
+	void OnStartCompleted(FName SessionName, bool bWasSuccessful);
+
+	// The delegate executed by the online subsystem
+	FOnStartSessionCompleteDelegate StartCompleteDelegate;
+
+	// Handles to the registered delegates above
+	FDelegateHandle StartCompleteDelegateHandle;
+
+	// The world context object in which this call is taking place
+	const UObject* WorldContextObject;
+};

--- a/AdvancedSessions/Source/AdvancedSessions/Private/CreateSessionCallbackProxyAdvanced.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/CreateSessionCallbackProxyAdvanced.cpp
@@ -13,7 +13,7 @@ UCreateSessionCallbackProxyAdvanced::UCreateSessionCallbackProxyAdvanced(const F
 {
 }
 
-UCreateSessionCallbackProxyAdvanced* UCreateSessionCallbackProxyAdvanced::CreateAdvancedSession(UObject* WorldContextObject, const TArray<FSessionPropertyKeyPair> &ExtraSettings, class APlayerController* PlayerController, int32 PublicConnections, int32 PrivateConnections, bool bUseLAN, bool bAllowInvites, bool bIsDedicatedServer, bool bUsePresence, bool bUseLobbiesIfAvailable, bool bAllowJoinViaPresence, bool bAllowJoinViaPresenceFriendsOnly, bool bAntiCheatProtected, bool bUsesStats, bool bShouldAdvertise, bool bUseLobbiesVoiceChatIfAvailable)
+UCreateSessionCallbackProxyAdvanced* UCreateSessionCallbackProxyAdvanced::CreateAdvancedSession(UObject* WorldContextObject, const TArray<FSessionPropertyKeyPair> &ExtraSettings, class APlayerController* PlayerController, int32 PublicConnections, int32 PrivateConnections, bool bUseLAN, bool bAllowInvites, bool bIsDedicatedServer, bool bUsePresence, bool bUseLobbiesIfAvailable, bool bAllowJoinViaPresence, bool bAllowJoinViaPresenceFriendsOnly, bool bAntiCheatProtected, bool bUsesStats, bool bShouldAdvertise, bool bUseLobbiesVoiceChatIfAvailable, bool bStartAfterCreate)
 {
 	UCreateSessionCallbackProxyAdvanced* Proxy = NewObject<UCreateSessionCallbackProxyAdvanced>();
 	Proxy->PlayerControllerWeakPtr = PlayerController;
@@ -32,6 +32,7 @@ UCreateSessionCallbackProxyAdvanced* UCreateSessionCallbackProxyAdvanced::Create
 	Proxy->bUsesStats = bUsesStats;
 	Proxy->bShouldAdvertise = bShouldAdvertise;
 	Proxy->bUseLobbiesVoiceChatIfAvailable = bUseLobbiesVoiceChatIfAvailable;
+	Proxy->bStartAfterCreate = bStartAfterCreate;
 	return Proxy;
 }
 
@@ -133,8 +134,17 @@ void UCreateSessionCallbackProxyAdvanced::OnCreateCompleted(FName SessionName, b
 			
 			if (bWasSuccessful)
 			{
-				StartCompleteDelegateHandle = Sessions->AddOnStartSessionCompleteDelegate_Handle(StartCompleteDelegate);
-				Sessions->StartSession(NAME_GameSession);
+				if(this->bStartAfterCreate)
+				{
+					UE_LOG_ONLINE_SESSION(Display, TEXT("Session creation completed. Automatic start is turned on, starting session now."));
+					StartCompleteDelegateHandle = Sessions->AddOnStartSessionCompleteDelegate_Handle(StartCompleteDelegate);
+					Sessions->StartSession(NAME_GameSession); // We'll call `OnSuccess.Broadcast()` when start succeeds.
+				}
+				else
+				{
+					UE_LOG_ONLINE_SESSION(Display, TEXT("Session creation completed. Automatic start is turned off, to start the session call 'StartSession'."));
+					OnSuccess.Broadcast();
+				}
 
 				// OnStartCompleted will get called, nothing more to do now
 				return;

--- a/AdvancedSessions/Source/AdvancedSessions/Private/StartSessionCallbackProxyAdvanced.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/StartSessionCallbackProxyAdvanced.cpp
@@ -1,0 +1,62 @@
+#include "StartSessionCallbackProxyAdvanced.h"
+
+UStartSessionCallbackProxyAdvanced::UStartSessionCallbackProxyAdvanced(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+	  , StartCompleteDelegate(FOnStartSessionCompleteDelegate::CreateUObject(this, &ThisClass::OnStartCompleted))
+{
+}
+
+UStartSessionCallbackProxyAdvanced* UStartSessionCallbackProxyAdvanced::StartAdvancedSession(
+	const UObject* WorldContextObject)
+{
+	UStartSessionCallbackProxyAdvanced* Proxy = NewObject<UStartSessionCallbackProxyAdvanced>();
+	Proxy->WorldContextObject = WorldContextObject;
+	return Proxy;
+}
+
+void UStartSessionCallbackProxyAdvanced::Activate()
+{
+	const FOnlineSubsystemBPCallHelperAdvanced Helper(
+		TEXT("StartSession"),
+		GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull));
+
+	if (Helper.OnlineSub != nullptr)
+	{
+		const auto Sessions = Helper.OnlineSub->GetSessionInterface();
+		if (Sessions.IsValid())
+		{
+			StartCompleteDelegateHandle = Sessions->AddOnStartSessionCompleteDelegate_Handle(StartCompleteDelegate);
+			Sessions->StartSession(NAME_GameSession);
+			return;
+		}
+		FFrame::KismetExecutionMessage(TEXT("Sessions not supported by Online Subsystem"), ELogVerbosity::Warning);
+	}
+
+	// Fail immediately
+	OnFailure.Broadcast();
+}
+
+void UStartSessionCallbackProxyAdvanced::OnStartCompleted(FName SessionName, bool bWasSuccessful)
+{
+	const FOnlineSubsystemBPCallHelperAdvanced Helper(
+		TEXT("StartSessionCallback"),
+		GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull));
+
+	if (Helper.OnlineSub != nullptr)
+	{
+		const auto Sessions = Helper.OnlineSub->GetSessionInterface();
+		if (Sessions.IsValid())
+		{
+			Sessions->ClearOnStartSessionCompleteDelegate_Handle(StartCompleteDelegateHandle);
+		}
+	}
+
+	if (bWasSuccessful)
+	{
+		OnSuccess.Broadcast();
+	}
+	else
+	{
+		OnFailure.Broadcast();
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/mordentral/AdvancedSessionsPlugin/issues/31

Sometimes, a game needs to create a game session but not to start it immediately.

For example, while waiting for players to join, the game session should be in state `EOnlineSessionState::Pending`, and when all the players have joined we can finally **_start_** the session which changes it's internal state to `EOnlineSessionState::InProgress`.

Currently, the node `CreateAdvancedSession` **_creates_** a game session immediately **_starts_** it.

So, I added the parameter `bStartAfterCreate` to the `CreateAdvancedSession` node (set to `true` by default so it doesn't break current implementations).

- If `bStartAfterCreate` is set to `true`, the game session will be **_created_** and also **_started_** immediately.
- If `bStartAfterCreate` is set to `false`, the game session will be **_created_** but not **_started_**.

Now, to **_start_** a game session I added the node `StartAdvancedSession`.

I didn't add a node to **_end_** a game session because such functionality already existed but was deprecated in b68199b1aad. However if needed, I can create another PR to re-enable the node `EndSession`.
