### PR TITLE
properly forward UWorld::ServerTravel return value

### DIFF
--- a/AdvancedSessions/Source/AdvancedSessions/Private/AdvancedSessionsLibrary.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/AdvancedSessionsLibrary.cpp
@@ -540,8 +540,7 @@ bool UAdvancedSessionsLibrary::ServerTravel(UObject* WorldContextObject, const F
 	UWorld* const World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::ReturnNull);
 	if (World)
 	{
-		World->ServerTravel(FURL, bAbsolute, bShouldSkipGameNotify);
-		return true;
+		return World->ServerTravel(FURL, bAbsolute, bShouldSkipGameNotify);
 	}
 
 	return false;


### PR DESCRIPTION
UWorld::ServerTravel returns a boolean, whether the ServerTravel can be performed (primarily checked by AGameMode::CanServerTravel).

The Blueprint Library Function in AdvancedSessionsLibrary does not consider that return value, and instead just returns true. I think it would be more appropriate to forward the return value of UWorld::ServerTravel.