### PR TITLE
Fix build on platforms other than Windows, Mac or Linux

### DIFF
--- a/AdvancedSteamSessions/Source/AdvancedSteamSessions/Classes/SteamNotificationsSubsystem.h
+++ b/AdvancedSteamSessions/Source/AdvancedSteamSessions/Classes/SteamNotificationsSubsystem.h
@@ -50,7 +50,7 @@ public:
 
 		}
 #else
-		cSteamEventsStore() :
+		cSteamEventsStore()
 		{
 
 		}


### PR DESCRIPTION
Fixes this error when building for Android, and probably other platforms (UE5.2.1):

```cpp
AdvancedSessionsPlugin/AdvancedSteamSessions/Source/AdvancedSteamSessions/Classes/SteamNotificationsSubsystem.h(54,3): error: expected class member or base class name
UATHelper: Packaging (Android (ASTC)):                 {
UATHelper: Packaging (Android (ASTC)):                 ^
UATHelper: Packaging (Android (ASTC)): 1 error generated.
UATHelper: Packaging (Android (ASTC)): [2/3] WriteMetadata Test-Android-Shipping.target cancelled
UATHelper: Packaging (Android (ASTC)): [3/3] clang++ Test-Android-Shipping-arm64.so cancelled
```