### PR TITLE
Fixed FindSessionsAdvanced not finding lobby sessions

### DIFF
--- a/AdvancedSessions/Source/AdvancedSessions/Private/FindSessionsCallbackProxyAdvanced.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/FindSessionsCallbackProxyAdvanced.cpp
@@ -113,7 +113,7 @@ void UFindSessionsCallbackProxyAdvanced::Activate()
 
 			case EBPServerPresenceSearchType::ClientServersOnly:
 			{
-				//tem.Set(SEARCH_PRESENCE, true, EOnlineComparisonOp::Equals);
+				tem.Set(SEARCH_PRESENCE, true, EOnlineComparisonOp::Equals);
 				
 				//if (bSearchLobbies)// && !IOnlineSubsystem::DoesInstanceExist("STEAM"))
 					tem.Set(SEARCH_LOBBIES, true, EOnlineComparisonOp::Equals);


### PR DESCRIPTION
**OSS used:** Steam

**Issue:**
When creating a session using the `CreateAdvancedSession` node and then using the `FindSessionsAdvanced` node, it causes the OSS to use the `FOnlineAsyncTaskSteamFindServers` task, which only finds "Game Servers", not "Lobbies".

**Solution:**
When selecting `Client Servers Only` in the `FindSessionsAdvanced` node, unless the user has explicitly chosen to init the game server interface for listen server hosting, they will be hosting lobbies, so the default should be to use the `FOnlineAsyncTaskSteamFindLobbiesForFindSessions` task instead