### PR TITLE
Add StartMatchmaking and CancelMatchmaking async nodes

### DIFF
--- a/AdvancedSessions/Source/AdvancedSessions/Classes/CancelMatchmakingCallbackProxy.h
+++ b/AdvancedSessions/Source/AdvancedSessions/Classes/CancelMatchmakingCallbackProxy.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "BlueprintDataDefinitions.h"
+#include "CancelMatchmakingCallbackProxy.generated.h"
+
+UCLASS(MinimalAPI)
+class UCancelMatchmakingCallbackProxy : public UOnlineBlueprintCallProxyBase
+{
+	GENERATED_BODY()
+
+	virtual void Activate() override;
+
+	void OnCancelMatchmakingComplete(FName SessionName, bool bWasSuccessful);
+
+	TWeakObjectPtr<APlayerController> PlayerControllerWeakPtr;
+
+	FOnCancelMatchmakingCompleteDelegate Delegate;
+
+	FDelegateHandle DelegateHandle;
+
+	TWeakObjectPtr<UObject> WorldContextObject;
+
+public:
+	UPROPERTY(BlueprintAssignable)
+	FEmptyOnlineDelegate OnSuccess;
+
+	UPROPERTY(BlueprintAssignable)
+	FEmptyOnlineDelegate OnFailure;
+
+	UFUNCTION(BlueprintCallable, meta=(BlueprintInternalUseOnly = "true", WorldContext="WorldContextObject"), Category = "Online|AdvancedSessions")
+	static UCancelMatchmakingCallbackProxy* CancelMatchmaking(UObject* WorldContextObject, APlayerController* PlayerController);
+};

--- a/AdvancedSessions/Source/AdvancedSessions/Classes/StartMatchmakingCallbackProxy.h
+++ b/AdvancedSessions/Source/AdvancedSessions/Classes/StartMatchmakingCallbackProxy.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "BlueprintDataDefinitions.h"
+#include "Net/OnlineBlueprintCallProxyBase.h"
+#include "StartMatchmakingCallbackProxy.generated.h"
+
+UCLASS(MinimalAPI)
+class UStartMatchmakingCallbackProxy : public UOnlineBlueprintCallProxyBase
+{
+	GENERATED_BODY()
+
+	TWeakObjectPtr<UObject> WorldContextObject;
+
+	TWeakObjectPtr<APlayerController> PlayerControllerWeakPtr;
+
+	TArray<FSessionsSearchSetting> Filters;
+
+	FDelegateHandle DelegateHandle;
+
+	UFUNCTION()
+	void OnMatchmakingComplete(FName SessionName, bool bWasSuccessful);
+
+public:
+	UPROPERTY(BlueprintAssignable)
+	FEmptyOnlineDelegate OnSuccess;
+
+	UPROPERTY(BlueprintAssignable)
+	FEmptyOnlineDelegate OnFailure;
+
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", AutoCreateRefTerm="Filters"), Category = "Online|AdvancedSessions")
+	static UStartMatchmakingCallbackProxy* StartMatchmaking(UObject* WorldContextObject, APlayerController* PlayerController, const TArray<FSessionsSearchSetting>& Filters);
+
+	virtual void Activate() override;
+};

--- a/AdvancedSessions/Source/AdvancedSessions/Private/CancelMatchmakingCallbackProxy.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/CancelMatchmakingCallbackProxy.cpp
@@ -1,0 +1,54 @@
+#include "CancelMatchmakingCallbackProxy.h"
+
+UCancelMatchmakingCallbackProxy* UCancelMatchmakingCallbackProxy::CancelMatchmaking(UObject* WorldContextObject, APlayerController* PlayerController)
+{
+	auto* Proxy = NewObject<UCancelMatchmakingCallbackProxy>();
+	Proxy->PlayerControllerWeakPtr = PlayerController;
+	Proxy->WorldContextObject = WorldContextObject;
+	return Proxy;
+}
+
+void UCancelMatchmakingCallbackProxy::Activate()
+{
+	FOnlineSubsystemBPCallHelperAdvanced Helper(TEXT("CancelMatchmakingCallbackProxy"), GEngine->GetWorldFromContextObject(WorldContextObject.Get(), EGetWorldErrorMode::LogAndReturnNull));
+	Helper.QueryIDFromPlayerController(PlayerControllerWeakPtr.Get());
+
+	if (Helper.IsValid())
+	{
+		if (const auto& Sessions = Helper.OnlineSub->GetSessionInterface())
+		{
+			DelegateHandle = Sessions->AddOnCancelMatchmakingCompleteDelegate_Handle(FOnMatchmakingCompleteDelegate::CreateUObject(this, &ThisClass::OnCancelMatchmakingComplete));
+			Sessions->CancelMatchmaking(*Helper.UserID, NAME_GameSession);
+			return;
+		}
+		else
+		{
+			FFrame::KismetExecutionMessage(TEXT("Sessions not supported by Online Subsystem"), ELogVerbosity::Warning);
+		}
+	}
+
+	OnFailure.Broadcast();
+}
+
+void UCancelMatchmakingCallbackProxy::OnCancelMatchmakingComplete(const FName SessionName, const bool bWasSuccessful)
+{
+	FOnlineSubsystemBPCallHelperAdvanced Helper(TEXT("CancelMatchmakingCallbackProxy"), GEngine->GetWorldFromContextObject(WorldContextObject.Get(), EGetWorldErrorMode::LogAndReturnNull));
+	Helper.QueryIDFromPlayerController(PlayerControllerWeakPtr.Get());
+
+	if (Helper.IsValid())
+	{
+		if (const auto& Sessions = Helper.OnlineSub->GetSessionInterface())
+		{
+			Sessions->ClearOnCancelMatchmakingCompleteDelegate_Handle(DelegateHandle);
+		}
+	}
+
+	if (bWasSuccessful)
+	{
+		OnSuccess.Broadcast();
+	}
+	else
+	{
+		OnFailure.Broadcast();
+	}
+}

--- a/AdvancedSessions/Source/AdvancedSessions/Private/StartMatchmakingCallbackProxy.cpp
+++ b/AdvancedSessions/Source/AdvancedSessions/Private/StartMatchmakingCallbackProxy.cpp
@@ -1,0 +1,82 @@
+#include "StartMatchmakingCallbackProxy.h"
+#include "Interfaces/OnlineSessionInterface.h"
+#include "OnlineSessionSettings.h"
+#include "OnlineSubsystemUtils.h"
+
+UStartMatchmakingCallbackProxy* UStartMatchmakingCallbackProxy::StartMatchmaking(UObject* WorldContextObject, APlayerController* PlayerController, const TArray<FSessionsSearchSetting>& Filters)
+{
+	auto* Proxy = NewObject<UStartMatchmakingCallbackProxy>();
+	Proxy->WorldContextObject = WorldContextObject;
+	Proxy->PlayerControllerWeakPtr = PlayerController;
+	Proxy->Filters = Filters;
+	return Proxy;
+}
+
+void UStartMatchmakingCallbackProxy::Activate()
+{
+	auto* World = GEngine->GetWorldFromContextObject(WorldContextObject.Get(), EGetWorldErrorMode::LogAndReturnNull);
+
+	FOnlineSubsystemBPCallHelperAdvanced Helper(TEXT("StartMatchmakingCallbackProxy"), World);
+	Helper.QueryIDFromPlayerController(PlayerControllerWeakPtr.Get());
+
+	if (World && Helper.IsValid())
+	{
+		if (const auto& SessionInt = Helper.OnlineSub->GetSessionInterface())
+		{
+			auto OnlineSearch = MakeShared<FOnlineSessionSearch>();
+
+			FOnlineSearchSettingsEx SearchSettings;
+			for (const auto& Filter : Filters)
+			{
+				SearchSettings.HardSet(Filter.PropertyKeyPair.Key, Filter.PropertyKeyPair.Data, Filter.ComparisonOp);
+			}
+			OnlineSearch->QuerySettings = SearchSettings;
+
+			TArray<TSharedRef<const FUniqueNetId>> LocalPlayers;
+			for (const auto* LocalPlayer : World->GetGameInstance()->GetLocalPlayers())
+			{
+				if (const auto& UniqueNetId = LocalPlayer->GetPreferredUniqueNetId(); UniqueNetId.IsValid())
+				{
+					LocalPlayers.Add(UniqueNetId->AsShared());
+				}
+			}
+
+			// TODO: What's the purpose of this?
+			const static FOnlineSessionSettings Dummy;
+
+			DelegateHandle = SessionInt->AddOnMatchmakingCompleteDelegate_Handle(FOnMatchmakingCompleteDelegate::CreateUObject(this, &ThisClass::OnMatchmakingComplete));
+			SessionInt->StartMatchmaking(LocalPlayers, NAME_GameSession, Dummy, OnlineSearch);
+			return;
+		}
+		else
+		{
+			FFrame::KismetExecutionMessage(TEXT("Sessions not supported by Online Subsystem"), ELogVerbosity::Warning);
+		}
+	}
+
+	OnFailure.Broadcast();
+}
+
+void UStartMatchmakingCallbackProxy::OnMatchmakingComplete(const FName SessionName, const bool bWasSuccessful)
+{
+	if (const auto* World = GEngine->GetWorldFromContextObject(WorldContextObject.Get(), EGetWorldErrorMode::LogAndReturnNull))
+	{
+		if (const auto& SessionInt = Online::GetSessionInterface(World))
+		{
+			SessionInt->ClearOnMatchmakingCompleteDelegate_Handle(DelegateHandle);
+
+			if (bWasSuccessful && PlayerControllerWeakPtr.IsValid())
+			{
+				if (FString ConnectString; SessionInt->GetResolvedConnectString(SessionName, ConnectString))
+				{
+					UE_LOG_ONLINE_SESSION(Log, TEXT("Matchmaking: traveling to %s"), *ConnectString);
+					PlayerControllerWeakPtr->ClientTravel(ConnectString, TRAVEL_Absolute);
+					OnSuccess.Broadcast();
+					return;
+				}
+			}
+		}
+	}
+
+	OnFailure.Broadcast();
+}


### PR DESCRIPTION
I am not fully certain I am using `StartMatchmaking` OSS method properly. Its docs are almost zero. The only existing OSS that I found that has `StartMatchmaking` implementation is [PlayFab](https://github.com/PlayFab/PlayFabMultiplayerUnreal/blob/v2.3.6/Source/Private/OnlineSessionInterfacePlayFab.cpp#L521), and that's what I based my `StartMatchmaking` usage on: `StartMatchmaking` is similar to `FindSessions` + `JoinSession`, it finds a single session and auto-joins to it, so we only need to perform a travel. What I didn't figure out is why `StartMatchmaking` wants `const FOnlineSessionSettings& NewSessionSettings`, so I am not filling it at all currently.

However, I am also implementing [my own OSS](https://github.com/slonopotamus/Atto) that (among other things) is [going to have](https://github.com/slonopotamus/Atto/pull/14) a working `StartMatchmaking` implementation.