### PR TITLE
Remove isteamapplist.h include

### DIFF
--- a/AdvancedSteamSessions/Source/AdvancedSteamSessions/Classes/AdvancedSteamFriendsLibrary.h
+++ b/AdvancedSteamSessions/Source/AdvancedSteamSessions/Classes/AdvancedSteamFriendsLibrary.h
@@ -42,7 +42,6 @@ MSVC_PRAGMA(warning(pop))
 #endif	// USING_CODE_ANALYSIS
 
 #include <steam/isteamapps.h>
-#include <steam/isteamapplist.h>
 //#include <OnlineSubsystemSteamTypes.h>
 #pragma pop_macro("ARRAY_COUNT")
 


### PR DESCRIPTION
SteamAppList is not actually used anywhere, and this header is no longer part of Steam SDK.